### PR TITLE
AddressGroup/Proxy: for members to be an array when there is only one member

### DIFF
--- a/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
+++ b/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
@@ -569,6 +569,11 @@ function Remove-FGTFirewallAddressGroupMember {
                 Throw "You can't remove all members. Use Remove-FGTFirewallAddressGroup to remove Address Group"
             }
 
+            #if there is only One member force to be an array
+            if ( $members.count -eq 1 ) {
+                $members = @($members)
+            }
+
             $_addrgrp | add-member -name "member" -membertype NoteProperty -Value $members
         }
 

--- a/PowerFGT/Public/cmdb/firewall/policy.ps1
+++ b/PowerFGT/Public/cmdb/firewall/policy.ps1
@@ -552,6 +552,11 @@ function Remove-FGTFirewallPolicyMember {
                 $members = $members | Where-Object { $_.name -ne $remove_member }
             }
 
+            #if there is only One or less member force to be an array
+            if ( $members.count -le 1 ) {
+                $members = @($members)
+            }
+
             $_policy | add-member -name "srcaddr" -membertype NoteProperty -Value $members
         }
 
@@ -568,6 +573,11 @@ function Remove-FGTFirewallPolicyMember {
             foreach ($remove_member in $dstaddr) {
                 #May be a better (and faster) solution...
                 $members = $members | Where-Object { $_.name -ne $remove_member }
+            }
+
+            #if there is only One or less member force to be an array
+            if ( $members.count -le 1 ) {
+                $members = @($members)
             }
 
             $_policy | add-member -name "dstaddr" -membertype NoteProperty -Value $members


### PR DESCRIPTION
otherwise, the member is not remove...

Fix #90