### PR TITLE
Policy: Remove action equal learn

### DIFF
--- a/PowerFGT/Public/cmdb/firewall/policy.ps1
+++ b/PowerFGT/Public/cmdb/firewall/policy.ps1
@@ -73,7 +73,7 @@ function Add-FGTFirewallPolicy {
         [Parameter (Mandatory = $true)]
         [string[]]$dstaddr,
         [Parameter (Mandatory = $false)]
-        [ValidateSet("accept", "deny", "learn")]
+        [ValidateSet("accept", "deny")]
         [string]$action = "accept",
         [Parameter (Mandatory = $false)]
         [switch]$status = $true,


### PR DESCRIPTION
it is only on GUI ! and not on API (need to set learning-mode field to enable)
Found when writing Pester test...