### PR TITLE
Visibility (Address and AddressGroup) is not longer available with FortiOS 6.4.x

### DIFF
--- a/PowerFGT/Public/cmdb/firewall/address.ps1
+++ b/PowerFGT/Public/cmdb/firewall/address.ps1
@@ -122,14 +122,22 @@ function Add-FGTFirewallAddress {
             $address | add-member -name "comment" -membertype NoteProperty -Value $comment
         }
 
+
         if ( $PsBoundParameters.ContainsKey('visibility') ) {
-            if ( $visibility ) {
-                $address | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+            #with 6.4.x, there is no longer visibility parameter
+            if ($connection.version -ge "6.4.0") {
+                Write-Warning "-visibility parameter is not longer available with FortiOS 6.4.x and after"
             }
             else {
-                $address | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                if ( $visibility ) {
+                    $address | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+                }
+                else {
+                    $address | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                }
             }
         }
+
 
         Invoke-FGTRestMethod -method "POST" -body $address -uri $uri -connection $connection @invokeParams | out-Null
 

--- a/PowerFGT/Public/cmdb/firewall/address.ps1
+++ b/PowerFGT/Public/cmdb/firewall/address.ps1
@@ -464,11 +464,17 @@ function Set-FGTFirewallAddress {
         }
 
         if ( $PsBoundParameters.ContainsKey('visibility') ) {
-            if ( $visibility ) {
-                $_address | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+            #with 6.4.x, there is no longer visibility parameter
+            if ($connection.version -ge "6.4.0") {
+                Write-Warning "-visibility parameter is not longer available with FortiOS 6.4.x and after"
             }
             else {
-                $_address | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                if ( $visibility ) {
+                    $_address | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+                }
+                else {
+                    $_address | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                }
             }
         }
 

--- a/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
+++ b/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
@@ -417,11 +417,17 @@ function Set-FGTFirewallAddressGroup {
         }
 
         if ( $PsBoundParameters.ContainsKey('visibility') ) {
-            if ( $visibility ) {
-                $_addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+            #with 6.4.x, there is no longer visibility parameter
+            if ($connection.version -ge "6.4.0") {
+                Write-Warning "-visibility parameter is not longer available with FortiOS 6.4.x and after"
             }
             else {
-                $_addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                if ( $visibility ) {
+                    $_addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+                }
+                else {
+                    $_addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                }
             }
         }
 

--- a/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
+++ b/PowerFGT/Public/cmdb/firewall/addressgroup.ps1
@@ -79,11 +79,17 @@ function Add-FGTFirewallAddressGroup {
         }
 
         if ( $PsBoundParameters.ContainsKey('visibility') ) {
-            if ( $visibility ) {
-                $addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+            #with 6.4.x, there is no longer visibility parameter
+            if ($connection.version -ge "6.4.0") {
+                Write-Warning "-visibility parameter is not longer available with FortiOS 6.4.x and after"
             }
             else {
-                $addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                if ( $visibility ) {
+                    $addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "enable"
+                }
+                else {
+                    $addrgrp | add-member -name "visibility" -membertype NoteProperty -Value "disable"
+                }
             }
         }
 

--- a/Tests/integration/FirewallAddress.Tests.ps1
+++ b/Tests/integration/FirewallAddress.Tests.ps1
@@ -85,7 +85,9 @@ Describe "Add Firewall Address" {
             $address.subnet | Should -Be "192.0.2.0 255.255.255.0"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address1 (type ipmask and interface)" {
@@ -99,7 +101,9 @@ Describe "Add Firewall Address" {
             $address.subnet | Should -Be "192.0.2.0 255.255.255.0"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address1 (type ipmask and comment)" {
@@ -113,7 +117,9 @@ Describe "Add Firewall Address" {
             $address.subnet | Should -Be "192.0.2.0 255.255.255.0"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -Be "Add via PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address1 (type ipmask and visiblity disable)" {
@@ -127,7 +133,9 @@ Describe "Add Firewall Address" {
             $address.subnet | Should -Be "192.0.2.0 255.255.255.0"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         It "Try to Add Address $pester_address1 (but there is already a object with same name)" {
@@ -155,7 +163,9 @@ Describe "Add Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address3 (type iprange and interface)" {
@@ -168,7 +178,9 @@ Describe "Add Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address3 (type iprange and comment)" {
@@ -181,7 +193,9 @@ Describe "Add Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -Be "Add via PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address3 (type iprange and visiblity disable)" {
@@ -194,7 +208,9 @@ Describe "Add Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         It "Try to Add Address $pester_address3 (but there is already a object with same name)" {
@@ -222,7 +238,9 @@ Describe "Add Firewall Address" {
             $address.fqdn | Should -be "fortipower.github.io"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address2 (type fqdn and interface)" {
@@ -235,7 +253,9 @@ Describe "Add Firewall Address" {
             $address.fqdn | Should -be "fortipower.github.io"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address2 (type fqdn and comment)" {
@@ -248,7 +268,9 @@ Describe "Add Firewall Address" {
             $address.fqdn | Should -be "fortipower.github.io"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -Be "Add via PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Add Address $pester_address2 (type fqdn and visiblity disable)" {
@@ -261,7 +283,9 @@ Describe "Add Firewall Address" {
             $address.fqdn | Should -be "fortipower.github.io"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
     }
@@ -288,7 +312,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.0"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change IP Mask" {
@@ -302,7 +328,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.128"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change (Associated) Interface" {
@@ -316,7 +344,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.128"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change comment" {
@@ -330,7 +360,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.128"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change visiblity" {
@@ -344,7 +376,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.128"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         It "Try to Configure Address $pester_address1 (but it is wrong type...)" {
@@ -362,7 +396,9 @@ Describe "Configure Firewall Address" {
             $address.subnet | Should -Be "192.0.3.0 255.255.255.128"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         AfterAll {
@@ -388,7 +424,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change End IP" {
@@ -401,7 +439,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.199"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change (Associated) Interface" {
@@ -414,7 +454,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.199"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change comment" {
@@ -427,7 +469,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.199"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change visiblity" {
@@ -440,7 +484,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.199"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         It "Try to Configure Address $pester_address3 (but it is wrong type...)" {
@@ -457,7 +503,9 @@ Describe "Configure Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.199"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         AfterAll {
@@ -482,7 +530,9 @@ Describe "Configure Firewall Address" {
             $address.fqdn | Should -Be "fortipower.github.com"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change (Associated) Interface" {
@@ -494,7 +544,9 @@ Describe "Configure Firewall Address" {
             $address.fqdn | Should -Be "fortipower.github.com"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change comment" {
@@ -506,7 +558,9 @@ Describe "Configure Firewall Address" {
             $address.fqdn | Should -Be "fortipower.github.com"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         It "Change visiblity" {
@@ -518,7 +572,9 @@ Describe "Configure Firewall Address" {
             $address.fqdn | Should -Be "fortipower.github.com"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         It "Try to Configure Address $pester_address2 (but it is wrong type...)" {
@@ -534,7 +590,9 @@ Describe "Configure Firewall Address" {
             $address.fqdn | Should -Be "fortipower.github.com"
             $address.'associated-interface' | Should -Be "port2"
             $address.comment | Should -Be "Modified by PowerFGT"
-            $address.visibility | Should -Be "disable"
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be "disable"
+            }
         }
 
         AfterAll {
@@ -564,7 +622,9 @@ Describe "Copy Firewall Address" {
             $address.subnet | Should -Be "192.0.2.0 255.255.255.0"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         AfterAll {
@@ -592,7 +652,9 @@ Describe "Copy Firewall Address" {
             $address.'end-ip' | Should -Be "192.0.2.100"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         AfterAll {
@@ -620,7 +682,9 @@ Describe "Copy Firewall Address" {
             $address.fqdn | Should -be "fortipower.github.io"
             $address.'associated-interface' | Should -BeNullOrEmpty
             $address.comment | Should -BeNullOrEmpty
-            $address.visibility | Should -Be $true
+            if ($DefaultFGTConnection.version -lt "6.4.0") {
+                $address.visibility | Should -Be $true
+            }
         }
 
         AfterAll {

--- a/Tests/integration/FirewallAddressGroup.Tests.ps1
+++ b/Tests/integration/FirewallAddressGroup.Tests.ps1
@@ -92,7 +92,9 @@ Describe "Add Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Add Address Group $pester_addressgroup1 (with 1 member and a comment)" {
@@ -103,7 +105,9 @@ Describe "Add Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -Be "Add via PowerFGT"
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Add Address Group $pester_addressgroup1 (with 1 member and visibility disable)" {
@@ -114,7 +118,9 @@ Describe "Add Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be "disable"
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be "disable"
+        }
     }
 
     It "Add Address Group $pester_addressgroup1 (with 2 members)" {
@@ -125,7 +131,9 @@ Describe "Add Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Try to Add Address Group $pester_addressgroup1 (but there is already a object with same name)" {
@@ -169,7 +177,9 @@ Describe "Add Firewall Address Group Member" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Add 2 members to Address Group $pester_addressgroup1 (with 1 member before)" {
@@ -180,7 +190,9 @@ Describe "Add Firewall Address Group Member" {
         ($addressgroup.member).count | Should -Be "3"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2, $pester_address3
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Add 2 members to Address Group $pester_addressgroup1 (with 2 members before)" {
@@ -192,7 +204,9 @@ Describe "Add Firewall Address Group Member" {
         ($addressgroup.member).count | Should -Be "4"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2, $pester_address3, $pester_address4
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     AfterAll {
@@ -223,7 +237,9 @@ Describe "Configure Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -Be "Modified by PowerFGT"
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Change visiblity" {
@@ -234,7 +250,9 @@ Describe "Configure Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -Be "Modified by PowerFGT"
-        $addressgroup.visibility | Should -Be "disable"
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be "disable"
+        }
     }
 
     It "Change 1 Member ($pester_address2)" {
@@ -245,7 +263,9 @@ Describe "Configure Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address2
         $addressgroup.comment | Should -Be "Modified by PowerFGT"
-        $addressgroup.visibility | Should -Be "disable"
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be "disable"
+        }
     }
 
     It "Change 2 Members ($pester_address1 and $pester_address2)" {
@@ -256,7 +276,9 @@ Describe "Configure Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2
         $addressgroup.comment | Should -Be "Modified by PowerFGT"
-        $addressgroup.visibility | Should -Be "disable"
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be "disable"
+        }
     }
 
     It "Change Name" {
@@ -267,7 +289,9 @@ Describe "Configure Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2
         $addressgroup.comment | Should -Be "Modified by PowerFGT"
-        $addressgroup.visibility | Should -Be "disable"
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be "disable"
+        }
     }
 
     AfterAll {
@@ -299,7 +323,9 @@ Describe "Copy Firewall Address Group" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address1, $pester_address2
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     AfterAll {
@@ -362,7 +388,9 @@ Describe "Remove Firewall Address Group Member" {
         ($addressgroup.member).count | Should -Be "2"
         $addressgroup.member.name | Should -BeIn $pester_address2, $pester_address3
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Remove 2 members to Address Group $pester_addressgroup1 (with 3 members before)" {
@@ -373,7 +401,9 @@ Describe "Remove Firewall Address Group Member" {
         ($addressgroup.member).count | Should -Be "1"
         $addressgroup.member.name | Should -BeIn $pester_address1
         $addressgroup.comment | Should -BeNullOrEmpty
-        $addressgroup.visibility | Should -Be $true
+        if ($DefaultFGTConnection.version -lt "6.4.0") {
+            $addressgroup.visibility | Should -Be $true
+        }
     }
 
     It "Try Remove 3 members to Address Group $pester_addressgroup1 (with 3 members before)" {


### PR DESCRIPTION
Add warning if you try to use visibility parameter with 6.4.x (and after)
Update test suite for don't check visibility