### PR TITLE
Fix PSSA warning with 1.20.0

### DIFF
--- a/PowerFGT/Public/cmdb/system/dns.ps1
+++ b/PowerFGT/Public/cmdb/system/dns.ps1
@@ -41,6 +41,7 @@ function Get-FGTSystemDns {
     #>
 
     [CmdletBinding(DefaultParameterSetName = "default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     Param(
         [Parameter (Mandatory = $false)]
         [Parameter (ParameterSetName = "filter")]

--- a/PowerFGT/Public/cmdb/system/settings.ps1
+++ b/PowerFGT/Public/cmdb/system/settings.ps1
@@ -40,6 +40,7 @@ function Get-FGTSystemSettings {
     #>
 
     [CmdletBinding(DefaultParameterSetName = "default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     Param(
         [Parameter (Mandatory = $false)]
         [Parameter (ParameterSetName = "filter")]


### PR DESCRIPTION
There is a new check (work with PS 7.0 about Use Singular Nouns

remove/disable the warning for Get-FGTSystemDNS and Get-FGTSystemSettings