### PR TITLE
Connection: Add check if info for get version is available

### DIFF
--- a/PowerFGT/Public/Connection.ps1
+++ b/PowerFGT/Public/Connection.ps1
@@ -275,7 +275,14 @@ function Connect-FGT {
         $connection.port = $port
         $connection.invokeParams = $invokeParams
         $connection.vdom = $vdom
-        $connection.version = [version]"$($version.results.current.major).$($version.results.current.minor).$($version.results.current.patch)"
+        if ($version.results.current.major) {
+            $connection.version = [version]"$($version.results.current.major).$($version.results.current.minor).$($version.results.current.patch)"
+        }
+        else {
+            #Old release like 5.x with no major/minor/patch
+            $connection.version = [version]"$($version.results.current.version -replace 'v','')"
+            Write-Warning "Old and no longer supported FortiOS with limited API (no filtering...)"
+        }
 
         if ( $DefaultConnection ) {
             set-variable -name DefaultFGTConnection -value $connection -scope Global


### PR DESCRIPTION
Not Available on some old release (and no longer supported) of FortiOS (5.x)
Add also a warning

Fix #141